### PR TITLE
C++: Revert changes to `cpp/constant-array-overflow`

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
@@ -168,9 +168,9 @@ module ArrayAddressToDerefConfig implements DataFlow::StateConfigSig {
     )
   }
 
-  predicate isBarrierIn(DataFlow::Node node, FlowState state) { isSource(node, state) }
+  predicate isBarrierIn(DataFlow::Node node) { isSource(node, _) }
 
-  predicate isBarrierOut(DataFlow::Node node, FlowState state) { isSink(node, state) }
+  predicate isBarrierOut(DataFlow::Node node) { isSink(node, _) }
 
   predicate isAdditionalFlowStep(
     DataFlow::Node node1, FlowState state1, DataFlow::Node node2, FlowState state2


### PR DESCRIPTION
It is not clear that this does what we want here, and the query is severly broken in any case.